### PR TITLE
server commit methods

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,0 +1,75 @@
+plugins {
+    kotlin("jvm")
+    jacoco
+    "com.github.ben-manes.versions"
+    `maven-publish`
+
+}
+repositories {
+    mavenCentral()
+    jcenter()
+    maven("https://dl.bintray.com/kotlin/kotlinx")
+    maven {
+        name = "titan"
+        url = uri("https://maven.titan-data.io")
+    }
+}
+
+dependencies {
+    compile(kotlin("stdlib"))
+    compile("io.titandata:remote-sdk:0.0.4")
+    compile("io.titandata:command-executor:0.1.0")
+    compile("com.google.code.gson:gson:2.8.6")
+    testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
+    testImplementation("io.mockk:mockk:1.9.3")
+}
+
+// Jar configuration
+group = "io.titandata"
+version = when(project.hasProperty("version")) {
+    true -> project.property("version")!!
+    false -> "latest"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+val jar by tasks.getting(Jar::class) {
+    archiveBaseName.set("ssh-remote")
+}
+
+// Maven publishing configuration
+val mavenBucket = when(project.hasProperty("mavenBucket")) {
+    true -> project.property("mavenBucket")
+    false -> "titan-data-maven"
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "io.titandata"
+            artifactId = "ssh-remote-server"
+
+            from(components["java"])
+        }
+    }
+
+    repositories {
+        maven {
+            name = "titan"
+            url = uri("s3://$mavenBucket")
+            authentication {
+                create<AwsImAuthentication>("awsIm")
+            }
+        }
+    }
+}
+
+// Test configuration
+
+tasks.test {
+    useJUnitPlatform()
+}
+

--- a/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
@@ -1,0 +1,84 @@
+package io.titandata.remote.ssh.server
+
+import com.google.gson.GsonBuilder
+import io.titandata.remote.RemoteServer
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+class SshRemoteServer : RemoteServer {
+
+    internal val gson = GsonBuilder().create()
+
+    /**
+     * This method will parse the remote configuration and parameters to determine if we should use password
+     * authentication or key-based authentication. It returns a pair where exactly one element must be set, either
+     * the first (password) or second (key).
+     */
+    internal fun getSshAuth(remote: Map<String, Any>, parameters: Map<String, Any> ): Pair<String?, String?> {
+        if (parameters["password"] != null && parameters["key"] != null) {
+            throw IllegalArgumentException("only one of password or key can be specified")
+        } else if (remote["password"] != null || parameters["password"] != null) {
+            return Pair((parameters["password"] ?: remote["password"]) as String, null)
+        } else if (parameters["key"] != null) {
+            return Pair(null, parameters["key"] as String)
+        } else {
+            throw IllegalArgumentException("one of password or key must be specified")
+        }
+    }
+
+    fun buildSshCommand(
+            remote: Map<String, Any>,
+            parameters: Map<String, Any>,
+            file: File,
+            includeAddress: Boolean,
+            vararg command: String
+    ): List<String> {
+        val args = mutableListOf<String>()
+
+        val (password, key) = getSshAuth(remote, parameters)
+
+        if (password != null) {
+            file.writeText(password)
+            args.addAll(arrayOf("sshpass", "-f", file.path, "ssh"))
+        } else {
+            file.writeText(key!!)
+            args.addAll(arrayOf("ssh", "-i", file.path))
+        }
+        Files.setPosixFilePermissions(file.toPath(), mutableSetOf(
+                PosixFilePermission.OWNER_READ
+        ))
+
+        if (remote["port"] != null) {
+            args.addAll(arrayOf("-p", remote["port"].toString()))
+        }
+
+        args.addAll(arrayOf("-o", "StrictHostKeyChecking=no"))
+        args.addAll(arrayOf("-o", "UserKnownHostsFile=/dev/null"))
+        if (includeAddress) {
+            args.add("${remote["username"]}@${remote["address"]}")
+        }
+        args.addAll(command)
+
+        return args
+    }
+
+
+    override fun getProvider(): String {
+        return "ssh"
+    }
+
+    /**
+     * The nop provider always returns success for any commit, and returns an empty set of properties.
+     */
+    override fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>? {
+        return emptyMap()
+    }
+
+    /**
+     * The nop provider always returns an empty list of commits.
+     */
+    override fun listCommits(remote: Map<String, Any>, parameters: Map<String, Any>, tags: List<Pair<String, String?>>): List<Pair<String, Map<String, Any>>> {
+        return emptyList()
+    }
+}

--- a/server/src/main/resources/META-INF/services/io.titandata.remote.RemoteServer
+++ b/server/src/main/resources/META-INF/services/io.titandata.remote.RemoteServer
@@ -1,0 +1,1 @@
+io.titandata.remote.ssh.server.SshRemoteServer

--- a/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
@@ -1,0 +1,94 @@
+package io.titandata.remote.ssh.server
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.io.File
+import java.lang.IllegalArgumentException
+import java.nio.file.Files
+
+class SshRemoteServerTest : StringSpec() {
+    private val client = SshRemoteServer()
+
+    private fun mockFile() : File {
+        mockkStatic("kotlin.io.FilesKt__FileReadWriteKt")
+        mockkStatic(Files::class)
+        val file : File = mockk()
+        every { file.path } returns "/path"
+        every { file.toPath() } returns mockk()
+        every { file.writeText(any()) } just Runs
+        every { Files.setPosixFilePermissions(any(), any()) } returns mockk()
+        return file
+    }
+
+    init {
+        "get provider returns ssh" {
+            client.getProvider() shouldBe "ssh"
+        }
+
+        "ssh auth fails if neither password nor key is specified in parameters" {
+            shouldThrow<IllegalArgumentException> {
+                client.getSshAuth(emptyMap(), emptyMap())
+            }
+        }
+
+        "ssh auth fails if both password and key is specified in parameters" {
+            shouldThrow<IllegalArgumentException> {
+                client.getSshAuth(emptyMap(), mapOf("password" to "password", "key" to "key"))
+            }
+        }
+
+        "ssh auth returns password if specified in parameters" {
+            val (password, key) = client.getSshAuth(emptyMap(), mapOf("password" to "password"))
+            password shouldBe "password"
+            key shouldBe null
+        }
+
+        "ssh auth returns password if specified in remote" {
+            val (password, key) = client.getSshAuth(mapOf("password" to "password"), emptyMap())
+            password shouldBe "password"
+            key shouldBe null
+        }
+
+        "ssh auth returns key if specified in parameters" {
+            val (password, key) = client.getSshAuth(emptyMap(), mapOf("key" to "key"))
+            password shouldBe null
+            key shouldBe "key"
+        }
+
+        "build SSH command uses sshpass for password authentication" {
+            val file = mockFile()
+            val command = client.buildSshCommand(emptyMap(), mapOf("password" to "password"), file, false)
+            command shouldBe arrayOf("sshpass", "-f", "/path", "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null")
+            verify {
+                file.writeText("password")
+            }
+        }
+
+        "build SSH command uses key file for key authentication" {
+            val file = mockFile()
+            val command = client.buildSshCommand(emptyMap(), mapOf("key" to "key"), file, false)
+            command shouldBe arrayOf("ssh", "-i", "/path", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null")
+            verify {
+                file.writeText("key")
+            }
+        }
+
+        "build SSH command with port and address succeeds" {
+            val file = mockFile()
+            val command = client.buildSshCommand(mapOf("port" to 1234, "username" to "user", "address" to "host"),
+                    mapOf("key" to "key"), file, true, "ls", "/var/tmp")
+            command shouldBe arrayOf("ssh", "-i", "/path", "-p", "1234", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "user@host", "ls", "/var/tmp")
+        }
+    }
+}

--- a/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
@@ -1,26 +1,49 @@
 package io.titandata.remote.ssh.server
 
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
+import io.mockk.MockKAnnotations
 import io.mockk.Runs
+import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.verify
+import io.titandata.shell.CommandException
+import io.titandata.shell.CommandExecutor
 import java.io.File
 import java.lang.IllegalArgumentException
 import java.nio.file.Files
 
 class SshRemoteServerTest : StringSpec() {
-    private val client = SshRemoteServer()
+    @MockK
+    lateinit var executor: CommandExecutor
 
-    private fun mockFile() : File {
+    @InjectMockKs
+    @OverrideMockKs
+    var client = SshRemoteServer()
+
+    override fun beforeTest(testCase: TestCase) {
+        return MockKAnnotations.init(this)
+    }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        clearAllMocks()
+    }
+
+    private fun mockFile(): File {
         mockkStatic("kotlin.io.FilesKt__FileReadWriteKt")
         mockkStatic(Files::class)
-        val file : File = mockk()
+        val file: File = mockk()
         every { file.path } returns "/path"
         every { file.toPath() } returns mockk()
         every { file.writeText(any()) } just Runs
@@ -89,6 +112,85 @@ class SshRemoteServerTest : StringSpec() {
                     mapOf("key" to "key"), file, true, "ls", "/var/tmp")
             command shouldBe arrayOf("ssh", "-i", "/path", "-p", "1234", "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null", "user@host", "ls", "/var/tmp")
+        }
+
+        "run ssh command invokes executor correctly" {
+            every { executor.exec(*anyVararg()) } returns ""
+            client.runSsh(mapOf("username" to "user", "address" to "host"), mapOf("key" to "key"), "ls", "-l")
+            verify {
+                executor.exec("ssh", "-i", any(), "-o", "StrictHostKeyChecking=no", "-o",
+                "UserKnownHostsFile=/dev/null", "user@host", "ls", "-l")
+            }
+        }
+
+        "get commit returns failure if file doesn't exist" {
+            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "No such file or directory")
+            val result = client.getCommit(mapOf("username" to "user", "address" to "host", "password" to "password"), emptyMap(), "id")
+            result shouldBe null
+        }
+
+        "get commit propagates unknown failures" {
+            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "")
+            shouldThrow<CommandException> {
+                client.getCommit(mapOf("username" to "user", "address" to "host", "password" to "password"), emptyMap(), "id")
+            }
+        }
+
+        "get commit returns correct metadata" {
+            every { executor.exec(*anyVararg()) } returns "{\"a\":\"b\"}"
+            val result = client.getCommit(mapOf("username" to "user", "address" to "host", "password" to "password"), emptyMap(), "id")
+            result shouldNotBe null
+            result!!["a"] shouldBe "b"
+        }
+
+        "temporary password file is correctly removed" {
+            val slot = slot<String>()
+            every { executor.exec("sshpass", "-f", capture(slot), *anyVararg()) } returns "{\"a\":\"b\"}"
+            client.getCommit(mapOf("username" to "user", "address" to "host", "password" to "password"), emptyMap(), "id")
+            val file = File(slot.captured)
+            file.exists() shouldBe false
+        }
+
+        "list commits returns an empty list" {
+            every { executor.exec(*anyVararg()) } returns ""
+            val result = client.listCommits(mapOf("username" to "user", "password" to "password", "address" to "host", "path" to "/var/tmp"), emptyMap(), emptyList())
+            result.size shouldBe 0
+        }
+
+        "list commits returns correct metadata" {
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "ls", "-1", "/var/tmp") } returns "a\nb\n"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"timestamp\":\"2019-09-20T13:45:36Z\"}"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/b/metadata.json") } returns "{\"timestamp\":\"2019-09-20T13:45:37Z\"}"
+            val result = client.listCommits(mapOf("username" to "root", "password" to "password", "address" to "localhost", "path" to "/var/tmp"), emptyMap(), emptyList())
+            result.size shouldBe 2
+            result[0].first shouldBe "b"
+            result[1].first shouldBe "a"
+        }
+
+        "list commits filters result" {
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "ls", "-1", "/var/tmp") } returns "a\nb\n"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"tags\":{\"c\":\"d\"}}"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/b/metadata.json") } returns "{}"
+            val result = client.listCommits(mapOf("username" to "root", "password" to "password", "address" to "localhost", "path" to "/var/tmp"), emptyMap(), listOf("c" to null))
+            result.size shouldBe 1
+            result[0].first shouldBe "a"
+        }
+
+        "list commits ignores missing file" {
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "ls", "-1", "/var/tmp") } returns "a\n"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } throws CommandException("", 1,
+                    "No such file or directory")
+
+            val result = client.listCommits(mapOf("username" to "root", "password" to "password", "address" to "localhost", "path" to "/var/tmp"), emptyMap(), emptyList())
+            result.size shouldBe 0
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 rootProject.name = "ssh-remote"
 
 include("client")
+include("server")


### PR DESCRIPTION
This adds the methods to fetch and list commits via the ssh provider.

## Testing

`gradle build` and verify coverage. Integrated into `titan-server` and tested functionality there.