### PR TITLE
remain compatible with existing ssh

### DIFF
--- a/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
@@ -141,7 +141,9 @@ class SshRemoteServer : RemoteServer {
     override fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>? {
         try {
             val json = runSsh(remote, parameters, "cat", "${remote["path"]}/$commitId/metadata.json")
-            return gson.fromJson(json, object : TypeToken<Map<String, Any>>() {}.type)
+            val result : Map<String, Any> = gson.fromJson(json, object : TypeToken<Map<String, Any>>() {}.type)
+            @Suppress("UNCHECKED_CAST")
+            return result.get("properties") as Map<String, Any>
         } catch (e: CommandException) {
             if (e.output.contains("No such file or directory")) {
                 return null


### PR DESCRIPTION
## Proposed Changes

For a little while, we're going to have the commit operations in external remotes but push/pull internally. I had been a bit too aggressive with changing the remote on-disk format for ssh. This rolls it back to be compatible with the in-tree remote.

## Testing

`gradle build`. Ran the SSH endtoend tests that were previously failing.