### PR TITLE
operations interfaces

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 }
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +18,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.7")
+    compile("io.titandata:remote-sdk:0.0.10")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 }
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,8 +18,8 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.7")
-    compile("io.titandata:command-executor:0.1.0")
+    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:command-executor:0.0.10")
     compile("com.google.code.gson:gson:2.8.6")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     compile("io.titandata:command-executor:0.0.10")
     compile("com.google.code.gson:gson:2.8.6")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")

--- a/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
@@ -141,7 +141,9 @@ class SshRemoteServer : RemoteServer {
     override fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>? {
         try {
             val json = runSsh(remote, parameters, "cat", "${remote["path"]}/$commitId/metadata.json")
-            return gson.fromJson(json, object : TypeToken<Map<String, Any>>() {}.type)
+            val result : Map<String, Any> = gson.fromJson(json, object : TypeToken<Map<String, Any>>() {}.type)
+            @Suppress("UNCHECKED_CAST")
+            return result.get("properties") as Map<String, Any>
         } catch (e: CommandException) {
             if (e.output.contains("No such file or directory")) {
                 return null

--- a/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
@@ -57,6 +57,7 @@ class SshRemoteServerTest : StringSpec() {
             parameters = mapOf("password" to "password"),
             operationId = "operation",
             commitId = "commit",
+            commit = null,
             type = RemoteOperationType.PUSH,
             data = null
     )


### PR DESCRIPTION
## Proposed Changes

This adds all the interfaces required by the new remote SDK. While I was here, I also cleaned up some copyright stuff and made it so you could link to libraries in your local maven repository.

## Testing

`gradle build`. Also ran all tests in `titan-server` (including endtoend tests) with new remote.