### PR TITLE
create commit directories as login user

### DIFF
--- a/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/ssh/server/SshRemoteServer.kt
@@ -220,7 +220,7 @@ class SshRemoteServer : RsyncRemote() {
     override fun getRsync(operation: RemoteOperation, operationData: Any?, src: String, dst: String, executor: CommandExecutor): RsyncExecutor {
         if (operation.type == RemoteOperationType.PUSH) {
             val remoteDir = dst.substringAfter(":")
-            runSsh(operation.remote, operation.parameters, "sudo", "mkdir", "-p", remoteDir)
+            runSsh(operation.remote, operation.parameters, "mkdir", "-p", remoteDir)
         }
 
         val (password, key) = getSshAuth(operation.remote, operation.parameters)

--- a/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/server/SshRemoteServerTest.kt
@@ -328,7 +328,7 @@ class SshRemoteServerTest : StringSpec() {
             every { spy.getSshAuth(any(), any()) } returns Pair("password", null)
             spy.getRsync(operation, null, "/src", "user@host:/path/commit/volume", executor)
             verify {
-                spy.runSsh(any(), any(), "sudo", "mkdir", "-p", "/path/commit/volume")
+                spy.runSsh(any(), any(), "mkdir", "-p", "/path/commit/volume")
             }
         }
 


### PR DESCRIPTION
## Issues Addressed

Fixes #8 

## Proposed Changes

As outlined in the issue report, this removes the "sudo" call when making the commit directory. The contents of the directory are still rsynced with sudo, but this fixes the issue as described in #8.

## Testing

Tested with updated `titan-server` endtoend test.